### PR TITLE
info about tabindex and focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,9 @@ Available methods:
 .bindAll(function, 'keydown' or 'keyup');   // bind all keys to this function, could be used for testing or demos.
 ```
 
+Common Pitfalls:
+
+You might feel tempted to use the keycharm library to bind keys to elements other than just form elements. Great, however, in this case you should be aware of the fact that besides giving focus to the element (e.g. programmatically `element.focus()`) you also need to add a tabindex! Simply focussing will *not* work.
+
+
 Keycharm is Dual-licensed with both the Apache 2.0 license as well as the MIT license. I'll leave it up to the user to pick which one they prefer.


### PR DESCRIPTION
Hi @AlexDM0

feel free to modify my comment as you wish

Sources that deal with this issue
- http://www.dbp-consulting.com/tutorials/canvas/CanvasKeyEvents.html

Here is a comment by jquery on this (which I did not include as quote in the pull..)

> The focus event is sent to an element when it gains focus. This event is implicitly applicable to a limited set of elements, such as form elements (<input>, <select>, etc.) and links (<a href>). In recent browser versions, the event can be extended to include all element types by explicitly setting the element's tabindex property.
> http://api.jquery.com/focus/

-Felix
