### PR TITLE
add ESM source module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,50 +1,91 @@
-keycharm
-========
+# keycharm
 
 Easy and free library for binding keys.
 
+## Install
+
 Keycharm is on npm so you can install it with:
-```
+
+```bash
 npm install keycharm
 ```
 
+## Import
 
-Example:
+### IIFE (browser)
 
+After importing the script `keycharm` is availible globally:
+
+```html
+<script src="https://unpkg.com/keycharm/keycharm.js">
 ```
-var keys = keycharm(options);
 
+### CommonJS
+
+```js
+const keycharm = require('keycharm');
+```
+
+### ESM
+
+```js
+import keycharm from 'keycharm';
+```
+
+## Usage
+
+```js
+var keys = keycharm(options);
 keys.bind("a", function () {}, 'keydown'); // key, callback function, 'keydown' or 'keyup'
 ```
 
-Available options (all are optional):
-```
+### Available options (all are optional)
+
+```js
 {
-    container: document.getElementById("element"), // optional div to bind keycharm to. It will NEED a tabindex. When not supplied, this defaults to window.
-    preventDefault: true/false // default value: false;
+    /* optional div to bind keycharm to.
+     * It will NEED a tabindex. When not supplied, this defaults to window. */
+    container: document.getElementById("element"),
+
+    /* swallow events (default: false) */
+    preventDefault: false
 }
 ```
 
-Supported keys:
+### Supported keys
 
-```
-'a'-'z', 'A'-'Z', '0'-'9', 'F1'-'F12', 'space', 'enter', 'ctrl', 'alt', 'tab', 'shift', 
-'delete', 'esc', 'backspace', '-','=', '[', ']', 'left', 'up', 'right', 'down', 'pageup', 'pagedown'
+```txt
+'a'-'z', 'A'-'Z', '0'-'9', 'space', 'enter', 'ctrl', 'alt', 'tab', 'shift', 'delete', 'backspace', '-', '=', '[', ']',
 
-numpad: 'num0'-'num9', 'num/', 'num*', 'num-', 'num+', 'num.'
+'esc', 'F1'-'F12', 'pageup', 'pagedown',
+
+'left', 'up', 'right', 'down',
+
+'num0'-'num9', 'num/', 'num*', 'num-', 'num+', 'num.'
 ```
 
 Each initiation of keycharm has its own bindings to the key events.
 
-Available methods:
+### Available methods
 
-```
-.bind(key, callback, [type]);               // bind key, type = 'keydown' or 'keyup', default type = keydown.
-.unbind(key, [callback], [type]);           // unbind key,  type = 'keydown' or 'keyup', default type = keydown. No callback deletes all bound callbacks from key
-.reset();                                   // remove all bound keys
-.destroy();                                 // remove all bound keys and the event listeners of keycharm
-.getKey(event);                             // get the key label of the event
-.bindAll(function, 'keydown' or 'keyup');   // bind all keys to this function, could be used for testing or demos.
+```js
+/* bind key, type = 'keydown' or 'keyup', default type = keydown. */
+.bind(key, callback, [type]);
+
+/* unbind key,  type = 'keydown' or 'keyup', default type = keydown. No callback deletes all bound callbacks from key */
+.unbind(key, [callback], [type]);
+
+/* remove all bound keys */
+.reset();
+
+/* remove all bound keys and the event listeners of keycharm */
+.destroy();
+
+/* get the key label of the event */
+.getKey(event);
+
+/* bind all keys to this function, could be used for testing or demos. */
+.bindAll(function, 'keydown' or 'keyup');
 ```
 
 Common Pitfalls:

--- a/keycharm.js
+++ b/keycharm.js
@@ -1,25 +1,12 @@
-"use strict";
-/**
- * Created by Alex on 11/6/2014.
- */
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.keycharm = factory());
+}(this, (function () { 'use strict';
 
-// https://github.com/umdjs/umd/blob/master/returnExports.js#L40-L60
-// if the module has no dependencies, the above pattern can be simplified to
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    // AMD. Register as an anonymous module.
-    define([], factory);
-  } else if (typeof exports === 'object') {
-    // Node. Does not work with strict CommonJS, but
-    // only CommonJS-like environments that support module.exports,
-    // like Node.
-    module.exports = factory();
-  } else {
-    // Browser globals (root is window)
-    root.keycharm = factory();
-  }
-}(this, function () {
-
+  /**
+   * Created by Alex on 11/6/2014.
+   */
   function keycharm(options) {
     var preventDefault = options && options.preventDefault || false;
 
@@ -188,6 +175,5 @@
   }
 
   return keycharm;
-}));
 
-
+})));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,198 @@
+{
+  "name": "keycharm",
+  "version": "0.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+      "dev": true
+    },
+    "pre-commit": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "spawn-sync": "^1.0.15",
+        "which": "1.2.x"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "rollup": {
+      "version": "2.28.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
+      "integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,17 @@
   "description": "Simple, lightweight key-binding lib",
   "version": "0.3.0",
   "license": "(Apache-2.0 OR MIT)",
+  "repository": "https://github.com/AlexDM0/keycharm",
   "main": "keycharm.js",
-  "repository": "https://github.com/AlexDM0/keycharm"
+  "module": "./src/keycharm.js",
+  "scripts": {
+    "build": "rollup ./src/keycharm.js --file keycharm.js --format umd --output.name keycharm"
+  },
+  "pre-commit": [
+    "build"
+  ],
+  "devDependencies": {
+    "pre-commit": "^1.2.2",
+    "rollup": "^2.28.2"
+  }
 }

--- a/src/keycharm.js
+++ b/src/keycharm.js
@@ -1,0 +1,169 @@
+/**
+ * Created by Alex on 11/6/2014.
+ */
+export default function keycharm(options) {
+  var preventDefault = options && options.preventDefault || false;
+
+  var container = options && options.container || window;
+
+  var _exportFunctions = {};
+  var _bound = {keydown:{}, keyup:{}};
+  var _keys = {};
+  var i;
+
+  // a - z
+  for (i = 97; i <= 122; i++) {_keys[String.fromCharCode(i)] = {code:65 + (i - 97), shift: false};}
+  // A - Z
+  for (i = 65; i <= 90; i++) {_keys[String.fromCharCode(i)] = {code:i, shift: true};}
+  // 0 - 9
+  for (i = 0;  i <= 9;   i++) {_keys['' + i] = {code:48 + i, shift: false};}
+  // F1 - F12
+  for (i = 1;  i <= 12;   i++) {_keys['F' + i] = {code:111 + i, shift: false};}
+  // num0 - num9
+  for (i = 0;  i <= 9;   i++) {_keys['num' + i] = {code:96 + i, shift: false};}
+
+  // numpad misc
+  _keys['num*'] = {code:106, shift: false};
+  _keys['num+'] = {code:107, shift: false};
+  _keys['num-'] = {code:109, shift: false};
+  _keys['num/'] = {code:111, shift: false};
+  _keys['num.'] = {code:110, shift: false};
+  // arrows
+  _keys['left']  = {code:37, shift: false};
+  _keys['up']    = {code:38, shift: false};
+  _keys['right'] = {code:39, shift: false};
+  _keys['down']  = {code:40, shift: false};
+  // extra keys
+  _keys['space'] = {code:32, shift: false};
+  _keys['enter'] = {code:13, shift: false};
+  _keys['shift'] = {code:16, shift: undefined};
+  _keys['esc']   = {code:27, shift: false};
+  _keys['backspace'] = {code:8, shift: false};
+  _keys['tab']       = {code:9, shift: false};
+  _keys['ctrl']      = {code:17, shift: false};
+  _keys['alt']       = {code:18, shift: false};
+  _keys['delete']    = {code:46, shift: false};
+  _keys['pageup']    = {code:33, shift: false};
+  _keys['pagedown']  = {code:34, shift: false};
+  // symbols
+  _keys['=']     = {code:187, shift: false};
+  _keys['-']     = {code:189, shift: false};
+  _keys[']']     = {code:221, shift: false};
+  _keys['[']     = {code:219, shift: false};
+
+
+
+  var down = function(event) {handleEvent(event,'keydown');};
+  var up = function(event) {handleEvent(event,'keyup');};
+
+  // handle the actualy bound key with the event
+  var handleEvent = function(event,type) {
+    if (_bound[type][event.keyCode] !== undefined) {
+      var bound = _bound[type][event.keyCode];
+      for (var i = 0; i < bound.length; i++) {
+        if (bound[i].shift === undefined) {
+          bound[i].fn(event);
+        }
+        else if (bound[i].shift == true && event.shiftKey == true) {
+          bound[i].fn(event);
+        }
+        else if (bound[i].shift == false && event.shiftKey == false) {
+          bound[i].fn(event);
+        }
+      }
+
+      if (preventDefault == true) {
+        event.preventDefault();
+      }
+    }
+  };
+
+  // bind a key to a callback
+  _exportFunctions.bind = function(key, callback, type) {
+    if (type === undefined) {
+      type = 'keydown';
+    }
+    if (_keys[key] === undefined) {
+      throw new Error("unsupported key: " + key);
+    }
+    if (_bound[type][_keys[key].code] === undefined) {
+      _bound[type][_keys[key].code] = [];
+    }
+    _bound[type][_keys[key].code].push({fn:callback, shift:_keys[key].shift});
+  };
+
+
+  // bind all keys to a call back (demo purposes)
+  _exportFunctions.bindAll = function(callback, type) {
+    if (type === undefined) {
+      type = 'keydown';
+    }
+    for (var key in _keys) {
+      if (_keys.hasOwnProperty(key)) {
+        _exportFunctions.bind(key,callback,type);
+      }
+    }
+  };
+
+  // get the key label from an event
+  _exportFunctions.getKey = function(event) {
+    for (var key in _keys) {
+      if (_keys.hasOwnProperty(key)) {
+        if (event.shiftKey == true && _keys[key].shift == true && event.keyCode == _keys[key].code) {
+          return key;
+        }
+        else if (event.shiftKey == false && _keys[key].shift == false && event.keyCode == _keys[key].code) {
+          return key;
+        }
+        else if (event.keyCode == _keys[key].code && key == 'shift') {
+          return key;
+        }
+      }
+    }
+    return "unknown key, currently not supported";
+  };
+
+  // unbind either a specific callback from a key or all of them (by leaving callback undefined)
+  _exportFunctions.unbind = function(key, callback, type) {
+    if (type === undefined) {
+      type = 'keydown';
+    }
+    if (_keys[key] === undefined) {
+      throw new Error("unsupported key: " + key);
+    }
+    if (callback !== undefined) {
+      var newBindings = [];
+      var bound = _bound[type][_keys[key].code];
+      if (bound !== undefined) {
+        for (var i = 0; i < bound.length; i++) {
+          if (!(bound[i].fn == callback && bound[i].shift == _keys[key].shift)) {
+            newBindings.push(_bound[type][_keys[key].code][i]);
+          }
+        }
+      }
+      _bound[type][_keys[key].code] = newBindings;
+    }
+    else {
+      _bound[type][_keys[key].code] = [];
+    }
+  };
+
+  // reset all bound variables.
+  _exportFunctions.reset = function() {
+    _bound = {keydown:{}, keyup:{}};
+  };
+
+  // unbind all listeners and reset all variables.
+  _exportFunctions.destroy = function() {
+    _bound = {keydown:{}, keyup:{}};
+    container.removeEventListener('keydown', down, true);
+    container.removeEventListener('keyup', up, true);
+  };
+
+  // create listeners.
+  container.addEventListener('keydown',down,true);
+  container.addEventListener('keyup',up,true);
+
+  // return the public functions.
+  return _exportFunctions;
+}


### PR DESCRIPTION
This fixes #9 

I did the following in this MR:
- convert `keycharm.js` from UMD to ESM module.
- moved the new ESM module source file to the `src` folder.
- added a rollup build script to bundle the ESM module to UMD.
- documanted the differnet imports in the README

I would recommend publishing this as a `minor` change, because the old `keycharm.js` file is still there and still supports UMD.